### PR TITLE
Hide modal on unmount

### DIFF
--- a/src/components/InvModal.js
+++ b/src/components/InvModal.js
@@ -13,9 +13,9 @@ import EditIcon from 'grommet/components/icons/base/Edit';
 
 class InvModal extends Component {
 
-  // componentWillUnmount() {
-  //   this.props.hideModal()
-  // }
+  componentWillUnmount() {
+    this.props.hideModal()
+  }
 
   render() {
   

--- a/src/components/InvModal.js
+++ b/src/components/InvModal.js
@@ -1,5 +1,5 @@
 // React Components
-import React from 'react';
+import React, { Component } from 'react';
 
 // Grommet Components
 import Box from 'grommet/components/Box';
@@ -11,9 +11,17 @@ import TableRow from 'grommet/components/TableRow';
 import Timestamp from 'grommet/components/Timestamp';
 import EditIcon from 'grommet/components/icons/base/Edit';
 
-const InvModal = ({ inventoryItem, selectItem, hideModal }) => {
+class InvModal extends Component {
 
-  return (
+  // componentWillUnmount() {
+  //   this.props.hideModal()
+  // }
+
+  render() {
+  
+    const { inventoryItem, selectItem, hideModal } = this.props
+
+    return (
       <Layer closer={true} onClose={ hideModal }>
         <Heading className='modalHeading' tag='h2' truncate={true}>
           {inventoryItem.name}
@@ -120,5 +128,6 @@ const InvModal = ({ inventoryItem, selectItem, hideModal }) => {
       </Layer>
     )
   }
+}
 
 export default InvModal;


### PR DESCRIPTION
Changed the component to a Class Component, moved props to their own const, and added a componentWillUnmount() to handle lifecycle issue with modal not disappearing when pressing Order in modal to navigate away, and then coming back to the inventory.

Now, the modal will hide itself when it is closed with the close button, or if the user navigates to a different page using the Order button.